### PR TITLE
automate service account used in postdeploy generation of info via ConfigMap, *PostDeploy: ConfigMap info in MD Format (10)

### DIFF
--- a/0-bootstrap/hub/1-infra/argocd/rbac/postdeploy-output-info/rbac-postdeploy-output-info.yaml
+++ b/0-bootstrap/hub/1-infra/argocd/rbac/postdeploy-output-info/rbac-postdeploy-output-info.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rbac-postdeploy-output-info
+  labels:
+    gitops.tier.layer: infra
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: rbac/postdeploy-output-info
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/hub/1-infra/kustomization.yaml
+++ b/0-bootstrap/hub/1-infra/kustomization.yaml
@@ -80,6 +80,9 @@ resources:
  #- argocd/namespaces/namespace-istio-system.yaml
  #- argocd/namespaces/namespace-ibm-cp4mcm.yaml
 
+# Postdeploy Markdown info in ConfigMap
+ - argocd/rbac/postdeploy-output-info/rbac-postdeploy-output-info.yaml
+
  # Quay Registry
  - argocd/namespaces/namespace-quay-registry.yaml
  


### PR DESCRIPTION
Should bring up the service account, and the required roles and rolebindings.